### PR TITLE
Fix CLI module path

### DIFF
--- a/bin/qc
+++ b/bin/qc
@@ -1,6 +1,10 @@
 #!/usr/bin/env node
 
-import QuantumCommander from '/workspaces/quantum-commander/lib/QuantumCommander.js';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const { default: QuantumCommander } = await import(join(__dirname, '../lib/QuantumCommander.js'));
 
 try {
   new QuantumCommander().run();


### PR DESCRIPTION
## Summary
- fix absolute module path in `bin/qc`

## Testing
- `npm test` *(fails: Missing script)*
- `node bin/qc --help`

------
https://chatgpt.com/codex/tasks/task_e_686a823c095083309c0cf390d25aa982