### PR TITLE
Load memory before processing commands

### DIFF
--- a/bin/qc
+++ b/bin/qc
@@ -1,9 +1,20 @@
 #!/usr/bin/env node
 
-import QuantumCommander from '/workspaces/quantum-commander/lib/QuantumCommander.js';
+import { existsSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+let commanderPath = resolve(here, '../lib/QuantumCommander.js');
+if (!existsSync(commanderPath)) {
+  commanderPath = resolve(here, 'lib/QuantumCommander.js');
+}
+
+const { default: QuantumCommander } = await import(`file://${commanderPath}`);
 
 try {
-  new QuantumCommander().run();
+  await new QuantumCommander().run();
 } catch (err) {
   console.error('[QuantumCommander] Startup failed:', err.message);
   process.exit(1);

--- a/install.sh
+++ b/install.sh
@@ -6,27 +6,30 @@ echo "🚀 Installing Quantum Commander globally..."
 
 # Create target directory
 INSTALL_DIR="$HOME/.quantum-commander"
-mkdir -p "$INSTALL_DIR"
+mkdir -p "$INSTALL_DIR/bin"
 
 # Copy files
 cp -r ./lib "$INSTALL_DIR/"
-cp ./bin/qc "$INSTALL_DIR/qc"
+cp -r ./node_modules "$INSTALL_DIR/"
+cp ./bin/qc "$INSTALL_DIR/bin/qc"
 
 # Make executable
-chmod +x "$INSTALL_DIR/qc"
+chmod +x "$INSTALL_DIR/bin/qc"
 
 # Symlink to /usr/local/bin (Linux) or ~/.local/bin fallback
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
   if [ -w /usr/local/bin ]; then
-    sudo ln -sf "$INSTALL_DIR/qc" /usr/local/bin/qc
+    sudo ln -sf "$INSTALL_DIR/bin/qc" /usr/local/bin/qc
   else
     mkdir -p "$HOME/.local/bin"
-    ln -sf "$INSTALL_DIR/qc" "$HOME/.local/bin/qc"
+    ln -sf "$INSTALL_DIR/bin/qc" "$HOME/.local/bin/qc"
     echo "🔗 Symlinked to ~/.local/bin/qc (add to your PATH if needed)"
   fi
 elif [[ "$OSTYPE" == "darwin"* ]]; then
-  ln -sf "$INSTALL_DIR/qc" /usr/local/bin/qc
+  ln -sf "$INSTALL_DIR/bin/qc" /usr/local/bin/qc
 else
+  mkdir -p "$HOME/.local/bin"
+  ln -sf "$INSTALL_DIR/bin/qc" "$HOME/.local/bin/qc"
   echo "⚠️ Manual symlink required. Add $INSTALL_DIR to your PATH."
 fi
 

--- a/lib/QuantumCognition.js
+++ b/lib/QuantumCognition.js
@@ -23,7 +23,8 @@ export default class QuantumCognition {
     try {
       await fs.access(this.memoryPath);
       const encrypted = await fs.readFile(this.memoryPath, 'utf-8');
-      this.memory = JSON.parse(decrypt(encrypted)) || {};
+      const decrypted = decrypt(encrypted);
+      this.memory = decrypted ? JSON.parse(decrypted) : {};
     } catch (e) {
       this.memory = {};
       if (e.code !== 'ENOENT') console.error('❌ Memory load failed:', e.message);

--- a/lib/QuantumCommander.js
+++ b/lib/QuantumCommander.js
@@ -107,7 +107,8 @@ export default class QuantumCommander {
       });
   }
 
-  run() {
+  async run() {
+    await this.cognition.loadMemory();
     this.program.parse(process.argv);
   }
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -6,29 +6,30 @@ echo "🚀 Installing Quantum Commander globally..."
 
 # Create target directory
 INSTALL_DIR="$HOME/.quantum-commander"
-mkdir -p "$INSTALL_DIR"
+mkdir -p "$INSTALL_DIR/bin"
 
 # Copy files
 cp -r ./lib "$INSTALL_DIR/"
-cp ./bin/qc "$INSTALL_DIR/qc"
+cp -r ./node_modules "$INSTALL_DIR/"
+cp ./bin/qc "$INSTALL_DIR/bin/qc"
 
 # Make executable
-chmod +x "$INSTALL_DIR/qc"
+chmod +x "$INSTALL_DIR/bin/qc"
 
 # Symlink to /usr/local/bin (Linux) or ~/.local/bin fallback
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
   if [ -w /usr/local/bin ]; then
-    sudo ln -sf "$INSTALL_DIR/qc" /usr/local/bin/qc
+    sudo ln -sf "$INSTALL_DIR/bin/qc" /usr/local/bin/qc
   else
     mkdir -p "$HOME/.local/bin"
-    ln -sf "$INSTALL_DIR/qc" "$HOME/.local/bin/qc"
+    ln -sf "$INSTALL_DIR/bin/qc" "$HOME/.local/bin/qc"
     echo "🔗 Symlinked to ~/.local/bin/qc (add to your PATH if needed)"
   fi
 elif [[ "$OSTYPE" == "darwin"* ]]; then
-  ln -sf "$INSTALL_DIR/qc" /usr/local/bin/qc
+  ln -sf "$INSTALL_DIR/bin/qc" /usr/local/bin/qc
 else
   mkdir -p "$HOME/.local/bin"
-  ln -sf "$INSTALL_DIR/qc" "$HOME/.local/bin/qc"
+  ln -sf "$INSTALL_DIR/bin/qc" "$HOME/.local/bin/qc"
   echo "⚠️ Manual symlink required. Add $INSTALL_DIR to your PATH."
 fi
 


### PR DESCRIPTION
## Summary
- initialize cognition memory when the CLI starts

## Testing
- `node bin/qc --help | head -n 20`
- `rm -rf /tmp/qc-test && mkdir -p /tmp/qc-test/bin && cp bin/qc /tmp/qc-test/bin/qc && cp -r lib /tmp/qc-test/lib && cp -r node_modules /tmp/qc-test/node_modules && node /tmp/qc-test/bin/qc --version | head -n 20`
- `node bin/qc learn "hello" "echo world" -t greet`
- `node bin/qc recall "hello"`

------
https://chatgpt.com/codex/tasks/task_e_685192c961c08330a52ac1f8bcbd8ba3