### PR TITLE
Add list command and close README code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Whether you’re automating tasks, securing workflows, or simply trying to remem
 - 🤖 **Suggest** alternatives when your memory draws a blank
 - ⬆️ **Upgrade** itself from a URL or GitHub repo
 - 🔒 Designed for **private use** and controlled self-enhancement
+- 🗂️ **List** saved commands with tags and metadata
 
 ---
 
@@ -29,5 +30,7 @@ npm link
 qc learn "start server" "npm run dev" -t dev,local
 qc recall "run server"
 qc suggest "build project"
+qc list
 qc upgrade --url https://yourdomain.com/modules/update.js
+```
 

--- a/lib/QuantumCommander.js
+++ b/lib/QuantumCommander.js
@@ -57,21 +57,35 @@ export default class QuantumCommander {
         }
       });
 
-    this.program.command('suggest <query>')
-      .description('Get AI-generated command suggestions')
-      .action(async (query) => {
-        try {
-          const suggestion = await this.cognition.recall(query, { suggest: true });
-          if (suggestion) {
-            console.log(chalk.yellow('🤖 AI Suggestion:'));
-            console.log(suggestion.command);
-          } else {
-            console.log(chalk.red('💡 No AI suggestions available.'));
+      this.program.command('suggest <query>')
+        .description('Get AI-generated command suggestions')
+        .action(async (query) => {
+          try {
+            const suggestion = await this.cognition.recall(query, { suggest: true });
+            if (suggestion) {
+              console.log(chalk.yellow('🤖 AI Suggestion:'));
+              console.log(suggestion.command);
+            } else {
+              console.log(chalk.red('💡 No AI suggestions available.'));
+            }
+          } catch (e) {
+            console.error(chalk.red('💥 Suggest failed:'), e.message);
           }
-        } catch (e) {
-          console.error(chalk.red('💥 Suggest failed:'), e.message);
-        }
-      });
+        });
+
+      this.program.command('list')
+        .description('List learned commands')
+        .option('-t, --tags <tags>', 'Filter by comma-separated tags', '')
+        .option('-s, --sort <method>', 'Sort by "recent" or "alphabetical"', 'recent')
+        .action(async ({ tags, sort }) => {
+          try {
+            const tagList = tags.split(',').filter(Boolean);
+            const output = this.cognition.list({ tags: tagList, sortBy: sort });
+            console.log(output);
+          } catch (e) {
+            console.error(chalk.red('💥 List failed:'), e.message);
+          }
+        });
 
     this.program.command('upgrade')
       .description('Upgrade core assistant modules from a URL or Git')


### PR DESCRIPTION
## Summary
- add new `list` command to QuantumCommander CLI
- document the list command and close the Quick Start code block

## Testing
- `node bin/qc list --help`
- `npm audit --production`


------
https://chatgpt.com/codex/tasks/task_e_686a8ebb1c708330acdf03c4679a7b8c